### PR TITLE
fixed bug that prevent selection of number of words

### DIFF
--- a/bip85/cli.py
+++ b/bip85/cli.py
@@ -46,6 +46,7 @@ def main():
                                   default='english',
                                   help='Language for BIP39 mnemonic')
     app_bip39_parser.add_argument('--num-words',
+                                  type=int,
                                   choices=(12, 15, 18, 21, 24),
                                   default=12,
                                   help='Number of words in the BIP39 mnemonic')


### PR DESCRIPTION
Before: number of words was not selectable due to bug, the following error would be displayed:
`bip85-cli bip39: error: argument --num-words: invalid choice: '24' (choose from 12, 15, 18, 21, 24)`
Now fixed.
Tested on Fedora 33, Python 3.9.2